### PR TITLE
Fix status bar totals after adding folders

### DIFF
--- a/src/commands/addFolder.ts
+++ b/src/commands/addFolder.ts
@@ -8,6 +8,7 @@ import {
   persistFileItems,
 } from "../core/state";
 import { isBinaryUri } from "../utils/fs";
+import { updateStatusBar } from "../ui/statusbar";
 
 export function registerAddFolder(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -43,6 +44,7 @@ export function registerAddFolder(context: vscode.ExtensionContext) {
           }
         }
         await persistFileItems(context);
+        updateStatusBar(consolidateItems);
       }
     )
   );


### PR DESCRIPTION
## Summary
- ensure the status bar refreshes after adding a folder to the consolidate list

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ee4bac1f508327ba80bec3336426ed